### PR TITLE
Fix lessons order: sort by title when dates are same

### DIFF
--- a/backend/src/routes/lessons.ts
+++ b/backend/src/routes/lessons.ts
@@ -142,7 +142,7 @@ router.get('/current', async (req: Request, res: Response) => {
         .select('*')
         .neq('status', 'skipped')
         .order('scheduled_date', { ascending: false })
-        .order('name', { ascending: false })
+        .order('name', { ascending: true })
         .limit(1);
       
       if (lastError) {

--- a/backend/src/routes/lessons.ts
+++ b/backend/src/routes/lessons.ts
@@ -45,7 +45,8 @@ router.get('/', async (req: Request, res: Response) => {
     let query = supabase
       .from('lessons')
       .select('*')
-      .order('scheduled_date', { ascending: true });
+      .order('scheduled_date', { ascending: true })
+      .order('name', { ascending: true });
     
     // Filter by status if provided
     if (status && typeof status === 'string') {
@@ -122,6 +123,7 @@ router.get('/current', async (req: Request, res: Response) => {
       .gte('scheduled_date', today)
       .neq('status', 'skipped')
       .order('scheduled_date', { ascending: true })
+      .order('name', { ascending: true })
       .limit(1);
     
     if (lessonsError) {
@@ -140,6 +142,7 @@ router.get('/current', async (req: Request, res: Response) => {
         .select('*')
         .neq('status', 'skipped')
         .order('scheduled_date', { ascending: false })
+        .order('name', { ascending: false })
         .limit(1);
       
       if (lastError) {

--- a/frontend/src/pages/LessonsPage.tsx
+++ b/frontend/src/pages/LessonsPage.tsx
@@ -105,6 +105,32 @@ const LessonsPage: React.FC = () => {
       default:
         return true;
     }
+  }).sort((a, b) => {
+    // Primary sort by date
+    const dateA = new Date(a.scheduled_date);
+    const dateB = new Date(b.scheduled_date);
+    const dateComparison = dateA.getTime() - dateB.getTime();
+    
+    if (dateComparison !== 0) {
+      return dateComparison;
+    }
+    
+    // Secondary sort by title with natural numeric sorting
+    // Extract lesson numbers for proper numeric comparison
+    const extractLessonNumber = (name: string) => {
+      const match = name.match(/Lesson (\d+)/);
+      return match ? parseInt(match[1], 10) : 0;
+    };
+    
+    const numberA = extractLessonNumber(a.name);
+    const numberB = extractLessonNumber(b.name);
+    
+    if (numberA !== numberB) {
+      return numberA - numberB;
+    }
+    
+    // Fallback to alphabetical sorting if no lesson numbers found
+    return a.name.localeCompare(b.name);
   });
 
   const getLessonStatus = (lesson: Lesson) => {


### PR DESCRIPTION
Fixed the lesson ordering issue by implementing proper sorting for lessons with the same date.

## Changes
- Backend: Added secondary sort by name field to all lesson queries
- Frontend: Added client-side natural numeric sorting for lesson titles
- Ensures Lesson 9 appears before Lesson 10, Lesson 11 before Lesson 12

Fixes #10

Generated with [Claude Code](https://claude.ai/code)